### PR TITLE
fix: allowance calculation in alligator

### DIFF
--- a/src/alligator/AlligatorOP_V5.sol
+++ b/src/alligator/AlligatorOP_V5.sol
@@ -80,7 +80,7 @@ contract AlligatorOPV5 is IAlligatorOPV5, UUPSUpgradeable, OwnableUpgradeable, P
     // Subdelegation rules `from` => `to`
     mapping(address from => mapping(address to => SubdelegationRules subdelegationRules)) public subdelegations;
 
-    mapping(address proxy => mapping(uint256 proposalId => mapping(address voter => uint256))) public UNUSED_SLOT;
+    mapping(address proxy => mapping(uint256 proposalId => mapping(address voter => uint256))) private UNUSED_SLOT;
 
     // Records of votes cast on `proposalId` by `delegate` with `proxy` voting power from those subdelegated by `delegator`.
     // Used to prevent double voting from the same proxy and authority chain.

--- a/src/interfaces/IAlligatorOPV5.sol
+++ b/src/interfaces/IAlligatorOPV5.sol
@@ -92,5 +92,8 @@ interface IAlligatorOPV5 {
 
     function proxyAddress(address owner) external view returns (address endpoint);
 
-    function votesCast(address proxy, uint256 proposalId, address voter) external view returns (uint256 votes);
+    function votesCast(address proxy, uint256 proposalId, address delegator, address delegate)
+        external
+        view
+        returns (uint256 votes);
 }

--- a/test/AlligatorOP.t.sol
+++ b/test/AlligatorOP.t.sol
@@ -457,7 +457,13 @@ contract AlligatorOPTest is SetupAlligatorOP {
 
     function standardCastVote(address[] memory authority) public virtual {
         vm.expectEmit();
-        emit VoteCast(_proxyAddress(authority[0], baseRules, baseRulesHash), address(this), authority, proposalId, 1);
+        emit VoteCast(
+            _proxyAddress(authority[0], baseRules, baseRulesHash),
+            authority[authority.length - 1],
+            authority,
+            proposalId,
+            1
+        );
         _castVote(baseRules, baseRulesHash, authority, proposalId, 1);
     }
 

--- a/test/AlligatorOP.t.sol
+++ b/test/AlligatorOP.t.sol
@@ -633,6 +633,229 @@ contract AlligatorOPTest is SetupAlligatorOP {
         }
     }
 
+    function createAuthorityChain(address[1] memory initAuthority)
+        internal
+        virtual
+        returns (address[] memory authority)
+    {
+        authority = new address[](initAuthority.length);
+        for (uint256 i = 0; i < initAuthority.length - 1; i++) {
+            authority[i] = initAuthority[i];
+
+            address node = initAuthority[i];
+            vm.prank(node);
+            _subdelegate(node, baseRules, initAuthority[i + 1], subdelegationRules);
+        }
+        authority[initAuthority.length - 1] = initAuthority[initAuthority.length - 1];
+
+        return authority;
+    }
+
+    function createAuthorityChain(address[2] memory initAuthority)
+        internal
+        virtual
+        returns (address[] memory authority)
+    {
+        authority = new address[](initAuthority.length);
+        for (uint256 i = 0; i < initAuthority.length - 1; i++) {
+            authority[i] = initAuthority[i];
+
+            address node = initAuthority[i];
+            vm.prank(node);
+            _subdelegate(node, baseRules, initAuthority[i + 1], subdelegationRules);
+        }
+        authority[initAuthority.length - 1] = initAuthority[initAuthority.length - 1];
+
+        return authority;
+    }
+
+    function createAuthorityChain(
+        address[2] memory initAuthority,
+        ReducedSubdelegationRules[1] memory initSubdelegationRules
+    ) internal virtual returns (address[] memory authority) {
+        authority = new address[](initAuthority.length);
+        for (uint256 i = 0; i < initAuthority.length - 1; i++) {
+            authority[i] = initAuthority[i];
+            ReducedSubdelegationRules memory rules = initSubdelegationRules[i];
+
+            address node = initAuthority[i];
+            vm.prank(node);
+            _subdelegate(
+                node,
+                baseRules,
+                initAuthority[i + 1],
+                SubdelegationRules(baseRules, rules.allowanceType, rules.allowance)
+            );
+        }
+        authority[initAuthority.length - 1] = initAuthority[initAuthority.length - 1];
+
+        return authority;
+    }
+
+    function createAuthorityChain(address[3] memory initAuthority)
+        internal
+        virtual
+        returns (address[] memory authority)
+    {
+        authority = new address[](initAuthority.length);
+        for (uint256 i = 0; i < initAuthority.length - 1; i++) {
+            authority[i] = initAuthority[i];
+
+            address node = initAuthority[i];
+            vm.prank(node);
+            _subdelegate(node, baseRules, initAuthority[i + 1], subdelegationRules);
+        }
+        authority[initAuthority.length - 1] = initAuthority[initAuthority.length - 1];
+
+        return authority;
+    }
+
+    function createAuthorityChain(
+        address[3] memory initAuthority,
+        ReducedSubdelegationRules[2] memory initSubdelegationRules
+    ) internal virtual returns (address[] memory authority) {
+        authority = new address[](initAuthority.length);
+        for (uint256 i = 0; i < initAuthority.length - 1; i++) {
+            authority[i] = initAuthority[i];
+            ReducedSubdelegationRules memory rules = initSubdelegationRules[i];
+
+            address node = initAuthority[i];
+            vm.prank(node);
+            _subdelegate(
+                node,
+                baseRules,
+                initAuthority[i + 1],
+                SubdelegationRules(baseRules, rules.allowanceType, rules.allowance)
+            );
+        }
+        authority[initAuthority.length - 1] = initAuthority[initAuthority.length - 1];
+
+        return authority;
+    }
+
+    function createAuthorityChain(address[4] memory initAuthority)
+        internal
+        virtual
+        returns (address[] memory authority)
+    {
+        authority = new address[](initAuthority.length);
+        for (uint256 i = 0; i < initAuthority.length - 1; i++) {
+            authority[i] = initAuthority[i];
+
+            address node = initAuthority[i];
+            vm.prank(node);
+            _subdelegate(node, baseRules, initAuthority[i + 1], subdelegationRules);
+        }
+        authority[initAuthority.length - 1] = initAuthority[initAuthority.length - 1];
+
+        return authority;
+    }
+
+    function createAuthorityChain(
+        address[4] memory initAuthority,
+        ReducedSubdelegationRules[3] memory initSubdelegationRules
+    ) internal virtual returns (address[] memory authority) {
+        authority = new address[](initAuthority.length);
+        for (uint256 i = 0; i < initAuthority.length - 1; i++) {
+            authority[i] = initAuthority[i];
+            ReducedSubdelegationRules memory rules = initSubdelegationRules[i];
+
+            address node = initAuthority[i];
+            vm.prank(node);
+            _subdelegate(
+                node,
+                baseRules,
+                initAuthority[i + 1],
+                SubdelegationRules(baseRules, rules.allowanceType, rules.allowance)
+            );
+        }
+        authority[initAuthority.length - 1] = initAuthority[initAuthority.length - 1];
+
+        return authority;
+    }
+
+    function createAuthorityChain(address[5] memory initAuthority)
+        internal
+        virtual
+        returns (address[] memory authority)
+    {
+        authority = new address[](initAuthority.length);
+        for (uint256 i = 0; i < initAuthority.length - 1; i++) {
+            authority[i] = initAuthority[i];
+
+            address node = initAuthority[i];
+            vm.prank(node);
+            _subdelegate(node, baseRules, initAuthority[i + 1], subdelegationRules);
+        }
+        authority[initAuthority.length - 1] = initAuthority[initAuthority.length - 1];
+
+        return authority;
+    }
+
+    function createAuthorityChain(
+        address[5] memory initAuthority,
+        ReducedSubdelegationRules[4] memory initSubdelegationRules
+    ) internal virtual returns (address[] memory authority) {
+        authority = new address[](initAuthority.length);
+        for (uint256 i = 0; i < initAuthority.length - 1; i++) {
+            authority[i] = initAuthority[i];
+            ReducedSubdelegationRules memory rules = initSubdelegationRules[i];
+
+            address node = initAuthority[i];
+            vm.prank(node);
+            _subdelegate(
+                node,
+                baseRules,
+                initAuthority[i + 1],
+                SubdelegationRules(baseRules, rules.allowanceType, rules.allowance)
+            );
+        }
+        authority[initAuthority.length - 1] = initAuthority[initAuthority.length - 1];
+
+        return authority;
+    }
+
+    function createAuthorityChain(address[6] memory initAuthority)
+        internal
+        virtual
+        returns (address[] memory authority)
+    {
+        authority = new address[](initAuthority.length);
+        for (uint256 i = 0; i < initAuthority.length - 1; i++) {
+            authority[i] = initAuthority[i];
+
+            address node = initAuthority[i];
+            vm.prank(node);
+            _subdelegate(node, baseRules, initAuthority[i + 1], subdelegationRules);
+        }
+        authority[initAuthority.length - 1] = initAuthority[initAuthority.length - 1];
+
+        return authority;
+    }
+
+    function createAuthorityChain(
+        address[6] memory initAuthority,
+        ReducedSubdelegationRules[5] memory initSubdelegationRules
+    ) internal virtual returns (address[] memory authority) {
+        authority = new address[](initAuthority.length);
+        for (uint256 i = 0; i < initAuthority.length - 1; i++) {
+            authority[i] = initAuthority[i];
+            ReducedSubdelegationRules memory rules = initSubdelegationRules[i];
+
+            address node = initAuthority[i];
+            vm.prank(node);
+            _subdelegate(
+                node,
+                baseRules,
+                initAuthority[i + 1],
+                SubdelegationRules(baseRules, rules.allowanceType, rules.allowance)
+            );
+        }
+        authority[initAuthority.length - 1] = initAuthority[initAuthority.length - 1];
+
+        return authority;
+    }
+
     /*//////////////////////////////////////////////////////////////
                               CALCULATIONS
     //////////////////////////////////////////////////////////////*/

--- a/test/AlligatorOPV5.t.sol
+++ b/test/AlligatorOPV5.t.sol
@@ -86,6 +86,91 @@ contract AlligatorOPV5Test is AlligatorOPTest {
         // stopMeasuringGas();
     }
 
+    function testCastVoteTwiceWithTwoChains_Alt() public virtual {
+        vm.prank(Utils.alice);
+        _subdelegate(Utils.alice, baseRules, voter, subdelegationRules);
+        vm.prank(Utils.alice);
+        _subdelegate(Utils.alice, baseRules, Utils.bob, subdelegationRules);
+        vm.prank(Utils.bob);
+        _subdelegate(Utils.bob, baseRules, Utils.carol, subdelegationRules);
+        vm.prank(voter);
+        _subdelegate(voter, baseRules, Utils.carol, subdelegationRules);
+
+        address[] memory authority1 = new address[](3);
+        authority1[0] = Utils.alice;
+        authority1[1] = voter;
+        authority1[2] = Utils.carol;
+
+        address[] memory authority2 = new address[](3);
+        authority2[0] = Utils.alice;
+        authority2[1] = Utils.bob;
+        authority2[2] = Utils.carol;
+
+        address[][] memory authorities = new address[][](2);
+        authorities[1] = authority1;
+        authorities[0] = authority2;
+
+        address[] memory proxies = new address[](2);
+        proxies[0] = _proxyAddress(Utils.alice, baseRules, baseRulesHash);
+        proxies[1] = _proxyAddress(Utils.alice, baseRules, baseRulesHash);
+
+        BaseRules[] memory proxyRules = new BaseRules[](2);
+        proxyRules[0] = baseRules;
+        proxyRules[1] = baseRules;
+
+        bytes32[] memory proxyRulesHashes = new bytes32[](2);
+        proxyRulesHashes[0] = baseRulesHash;
+        proxyRulesHashes[1] = baseRulesHash;
+
+        standardCastVoteWithReasonAndParamsBatched(
+            authorities, proxies, proxyRules, proxyRulesHashes, "reason", "params"
+        );
+
+        (, uint256 forVotes,) = GovernorCountingSimpleUpgradeableV2(governor).proposalVotes(proposalId);
+        assertEq(forVotes, 50e18);
+    }
+
+    function testCastVoteTwiceWithTwoChains() public virtual {
+        vm.prank(Utils.alice);
+        _subdelegate(Utils.alice, baseRules, Utils.carol, subdelegationRules);
+        vm.prank(Utils.alice);
+        _subdelegate(Utils.alice, baseRules, Utils.bob, subdelegationRules);
+        vm.prank(Utils.bob);
+        _subdelegate(Utils.bob, baseRules, Utils.carol, subdelegationRules);
+
+        address[] memory authority1 = new address[](2);
+        authority1[0] = Utils.alice;
+        authority1[1] = Utils.carol;
+
+        address[] memory authority2 = new address[](3);
+        authority2[0] = Utils.alice;
+        authority2[1] = Utils.bob;
+        authority2[2] = Utils.carol;
+
+        address[][] memory authorities = new address[][](2);
+        authorities[1] = authority1;
+        authorities[0] = authority2;
+
+        address[] memory proxies = new address[](2);
+        proxies[0] = _proxyAddress(Utils.alice, baseRules, baseRulesHash);
+        proxies[1] = _proxyAddress(Utils.alice, baseRules, baseRulesHash);
+
+        BaseRules[] memory proxyRules = new BaseRules[](2);
+        proxyRules[0] = baseRules;
+        proxyRules[1] = baseRules;
+
+        bytes32[] memory proxyRulesHashes = new bytes32[](2);
+        proxyRulesHashes[0] = baseRulesHash;
+        proxyRulesHashes[1] = baseRulesHash;
+
+        standardCastVoteWithReasonAndParamsBatched(
+            authorities, proxies, proxyRules, proxyRulesHashes, "reason", "params"
+        );
+
+        (, uint256 forVotes,) = GovernorCountingSimpleUpgradeableV2(governor).proposalVotes(proposalId);
+        assertEq(forVotes, 75e18);
+    }
+
     function testLimitedCastVoteWithReasonAndParamsBatched() public virtual {
         (address[][] memory authorities,, BaseRules[] memory proxyRules, bytes32[] memory proxyRulesHashes) =
             _formatBatchData();
@@ -468,8 +553,8 @@ contract AlligatorOPV5Test is AlligatorOPTest {
         votesToCast_[proxy] += votesToCast;
         initWeightCast = governor.weightCast(proposalId, proxy);
         initWeights = new uint256[](authority.length);
-        for (uint256 i; i < authority.length; ++i) {
-            initWeights[i] = AlligatorOPV5Mock(alligator).votesCast(proxy, proposalId, authority[i]);
+        for (uint256 i = 1; i < authority.length; ++i) {
+            initWeights[i] = AlligatorOPV5Mock(alligator).votesCast(proxy, proposalId, authority[i - 1], authority[i]);
         }
     }
 
@@ -488,8 +573,9 @@ contract AlligatorOPV5Test is AlligatorOPTest {
         assertEq(governor.weightCast(proposalId, proxy), initWeightCast + votesToCast);
         assertEq(finalForVotes, initForVotes + votesToCast);
 
-        for (uint256 i; i < authority.length; ++i) {
-            uint256 recordedVotes = AlligatorOPV5Mock(alligator).votesCast(proxy, proposalId, authority[i]);
+        for (uint256 i = 1; i < authority.length; ++i) {
+            uint256 recordedVotes =
+                AlligatorOPV5Mock(alligator).votesCast(proxy, proposalId, authority[i - 1], authority[i]);
             assertEq(recordedVotes, (k == 0 || i < k) ? initWeights[i] : initWeights[i] + votesToCast);
         }
     }
@@ -516,8 +602,9 @@ contract AlligatorOPV5Test is AlligatorOPTest {
                 assertTrue(governor.hasVoted(proposalId, proxy));
                 assertEq(governor.weightCast(proposalId, proxy), initWeightCast[i] + votesToCast_[proxy]);
 
-                for (uint256 l; l < authority.length; ++l) {
-                    uint256 recordedVotes = AlligatorOPV5Mock(alligator).votesCast(proxy, proposalId, authority[l]);
+                for (uint256 l = 1; l < authority.length; ++l) {
+                    uint256 recordedVotes =
+                        AlligatorOPV5Mock(alligator).votesCast(proxy, proposalId, authority[l - 1], authority[l]);
                     assertEq(
                         recordedVotes, (k[i] == 0 || l < k[i]) ? initWeights[i][l] : initWeights[i][l] + votesToCast[i]
                     );

--- a/test/AlligatorOPV5.t.sol
+++ b/test/AlligatorOPV5.t.sol
@@ -64,6 +64,28 @@ contract AlligatorOPV5Test is AlligatorOPTest {
         assertEq(forVotes, 75e18);
     }
 
+    function testCastVoteMaxRedelegations() public virtual {
+        uint256 length = 255;
+        subdelegationRules.allowanceType = AllowanceType.Absolute;
+        address[] memory authority = new address[](length + 1);
+        authority[0] = Utils.alice;
+        for (uint256 i = 0; i < length; i++) {
+            address delegator = i == 0 ? authority[0] : address(uint160(i));
+            address delegate = address(uint160(i + 1));
+            subdelegationRules.allowance = 1e18 - 10 * i;
+            vm.prank(delegator);
+            _subdelegate(delegator, baseRules, delegate, subdelegationRules);
+
+            authority[i + 1] = delegate;
+        }
+
+        // startMeasuringGas("castVote with max chain length - partial allowances");
+        vm.startPrank(address(uint160(length)));
+        standardCastVote(authority);
+        vm.stopPrank();
+        // stopMeasuringGas();
+    }
+
     function testLimitedCastVoteWithReasonAndParamsBatched() public virtual {
         (address[][] memory authorities,, BaseRules[] memory proxyRules, bytes32[] memory proxyRulesHashes) =
             _formatBatchData();

--- a/test/AlligatorOPV5.t.sol
+++ b/test/AlligatorOPV5.t.sol
@@ -1103,4 +1103,91 @@ contract AlligatorOPV5Test is AlligatorOPTest {
             maxVotingPower, authorities, propId, support, reason, params, v, r, s
         );
     }
+
+    function createBasicAuthorities(address[][1] memory initAuthorities)
+        internal
+        virtual
+        returns (
+            address[][] memory authorities,
+            address[] memory proxies,
+            BaseRules[] memory proxyRules,
+            bytes32[] memory proxyRulesHashes,
+            uint256 totalVotesToCast
+        )
+    {
+        authorities = new address[][](initAuthorities.length);
+        proxies = new address[](initAuthorities.length);
+        proxyRules = new BaseRules[](initAuthorities.length);
+        proxyRulesHashes = new bytes32[](initAuthorities.length);
+
+        uint256[] memory votesToCast = new uint256[](authorities.length);
+
+        for (uint256 i = 0; i < initAuthorities.length; i++) {
+            authorities[i] = initAuthorities[i];
+            proxies[i] = _proxyAddress(authorities[i][0], baseRules, baseRulesHash);
+            proxyRules[i] = baseRules;
+            proxyRulesHashes[i] = baseRulesHash;
+
+            (, votesToCast[i],,) = _getInitParams(authorities[i]);
+            totalVotesToCast += votesToCast[i];
+        }
+    }
+
+    function createBasicAuthorities(address[][2] memory initAuthorities)
+        internal
+        virtual
+        returns (
+            address[][] memory authorities,
+            address[] memory proxies,
+            BaseRules[] memory proxyRules,
+            bytes32[] memory proxyRulesHashes,
+            uint256 totalVotesToCast
+        )
+    {
+        authorities = new address[][](initAuthorities.length);
+        proxies = new address[](initAuthorities.length);
+        proxyRules = new BaseRules[](initAuthorities.length);
+        proxyRulesHashes = new bytes32[](initAuthorities.length);
+
+        uint256[] memory votesToCast = new uint256[](authorities.length);
+
+        for (uint256 i = 0; i < initAuthorities.length; i++) {
+            authorities[i] = initAuthorities[i];
+            proxies[i] = _proxyAddress(authorities[i][0], baseRules, baseRulesHash);
+            proxyRules[i] = baseRules;
+            proxyRulesHashes[i] = baseRulesHash;
+
+            (, votesToCast[i],,) = _getInitParams(authorities[i]);
+            totalVotesToCast += votesToCast[i];
+        }
+    }
+
+    function createBasicAuthorities(address[][3] memory initAuthorities)
+        internal
+        virtual
+        returns (
+            address[][] memory authorities,
+            address[] memory proxies,
+            BaseRules[] memory proxyRules,
+            bytes32[] memory proxyRulesHashes,
+            uint256 totalVotesToCast
+        )
+    {
+        authorities = new address[][](initAuthorities.length);
+        proxies = new address[](initAuthorities.length);
+        proxyRules = new BaseRules[](initAuthorities.length);
+        proxyRulesHashes = new bytes32[](initAuthorities.length);
+
+        uint256[] memory votesToCast = new uint256[](authorities.length);
+
+        for (uint256 i = 0; i < initAuthorities.length; i++) {
+            authorities[i] = initAuthorities[i];
+            proxies[i] = _proxyAddress(authorities[i][0], baseRules, baseRulesHash);
+            proxyRules[i] = baseRules;
+            proxyRulesHashes[i] = baseRulesHash;
+
+            (, votesToCast[i],,) = _getInitParams(authorities[i]);
+            totalVotesToCast += votesToCast[i];
+        }
+    }
 }

--- a/test/setup/SetupAlligatorOP.sol
+++ b/test/setup/SetupAlligatorOP.sol
@@ -102,6 +102,11 @@ abstract contract SetupAlligatorOP is Test {
     uint256 proposalId;
     address signer = vm.rememberKey(vm.envUint("SIGNER_KEY"));
 
+    struct ReducedSubdelegationRules {
+        AllowanceType allowanceType;
+        uint256 allowance;
+    }
+
     // =============================================================
     //                             SETUP
     // =============================================================


### PR DESCRIPTION
fixes how allowances are calculated in complex subdelegation scenarios.

the main correction comes from the assumption that:
- absolute allowances are related to **all votes cast by a delegate** regardless of authority chains
- relative allowances are related to **votes cast by a delegate via a certain authority chain**

this should fix should solve most scenarios, but more tests (especially fuzz) are needed to make sure all edge cases are covered and the desired outcome is always achieved.

---

Note: this also adds new helpers useful for writing tests
- `createAuthorityChain`
- `createBasicAuthorities`